### PR TITLE
check for the existence of file instead of url

### DIFF
--- a/lib/copy_carrierwave_file/copy_file_service.rb
+++ b/lib/copy_carrierwave_file/copy_file_service.rb
@@ -34,7 +34,7 @@ module CopyCarrierwaveFile
     end
 
     def have_file?
-      original_resource_mounter.url.present?
+      original_resource_mounter.file.present?
     end
 
     # Set file when you use remote storage for your files (like S3)


### PR DESCRIPTION
A resource has no file, when a default_url is provided. However if you check for the presence of url, it will pass it. This will cause an error (cannot read file from nill class).

Checking for the presence of file solves this.
