### PR TITLE
Ask for storage

### DIFF
--- a/copy_carrierwave_file.gemspec
+++ b/copy_carrierwave_file.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5"
   spec.add_development_dependency "mocha", "~> 0.14"
   spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "fog"
+  spec.add_development_dependency "pry"
 end

--- a/test/copy_file_service_wrong_initialization_test.rb
+++ b/test/copy_file_service_wrong_initialization_test.rb
@@ -9,13 +9,13 @@ describe CopyCarrierwaveFile::CopyFileService, 'initialization' do
 
   context 'with resources with uploader and right mount point' do
     it "should not raise an error" do
-      CopyCarrierwaveFile::CopyFileService.new(Document.new, Document.new, :file)
+      CopyCarrierwaveFile::CopyFileService.new(LocalDocument.new, LocalDocument.new, :file)
     end
   end
 
   context 'when original resources without uploader' do
     it "should raise an error" do
-      proc{ CopyCarrierwaveFile::CopyFileService.new(User.new, Document.new, :file) }.
+      proc{ CopyCarrierwaveFile::CopyFileService.new(User.new, LocalDocument.new, :file) }.
         must_raise RuntimeError
     end
   end
@@ -23,14 +23,14 @@ describe CopyCarrierwaveFile::CopyFileService, 'initialization' do
 
   context 'when resources without uploader' do
     it "should raise an error" do
-      proc{ CopyCarrierwaveFile::CopyFileService.new(Document.new, User.new, :file) }.
+      proc{ CopyCarrierwaveFile::CopyFileService.new(LocalDocument.new, User.new, :file) }.
         must_raise RuntimeError
     end
   end
 
   context 'with resources with uploader but wrong mount point' do
     it do
-      proc{ CopyCarrierwaveFile::CopyFileService.new(Document.new, Document.new, :foo) }.
+      proc{ CopyCarrierwaveFile::CopyFileService.new(LocalDocument.new, LocalDocument.new, :foo) }.
         must_raise RuntimeError
     end
   end

--- a/test/copy_local_storage_file_test.rb
+++ b/test/copy_local_storage_file_test.rb
@@ -7,10 +7,10 @@ describe 'CopyCarrierwaveFile', 'copying local storage file' do
     FileUtils.rm_rf(Dir.glob(TEST_DIR+"/tmp/uploads/*"))
   end
 
-  let(:document)    { Document.new }
+  let(:document)    { LocalDocument.new }
   let(:copy_service){ CopyCarrierwaveFile::CopyFileService.new(original_document, document, :file)}
   let(:original_document) do
-    doc = Document.new
+    doc = LocalDocument.new
     doc.file = test_file1
     doc.save
     doc

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,11 +16,12 @@ class Minitest::Spec
   end
 end
 
+Fog.mock!
+
 ActiveRecord::Base::establish_connection(adapter: 'sqlite3', database: ':memory:')
 ActiveRecord::Base.connection.execute(%{CREATE TABLE documents (id INTEGER PRIMARY KEY, file STRING );})
 
-
-class FileUploader < CarrierWave::Uploader::Base
+class LocalFileUploader < CarrierWave::Uploader::Base
   storage :file
 
   def root
@@ -28,13 +29,25 @@ class FileUploader < CarrierWave::Uploader::Base
   end
 end
 
+class RemoteFileUploader < CarrierWave::Uploader::Base
+  storage :fog
+
+  def root
+    "#{TEST_DIR}/tmp/" # 
+  end
+end
 
 class Document < ActiveRecord::Base
-  mount_uploader :file, FileUploader
+end
+
+class LocalDocument < Document
+  mount_uploader :file, LocalFileUploader
+end
+
+class RemoteDocument < Document
+  mount_uploader :file, RemoteFileUploader
 end
 
 def remove_uploaded_test_files
   FileUtils.rm_rf(Dir.glob(TEST_DIR+"/tmp/uploads/*"))
 end
-
-


### PR DESCRIPTION
asking carrier-wave for storage rather than guessing from exception + use native `resource.remote_image_url = 'http://eq8.eu/gn.png'` instead of using custom OpenURI.open
