### PR TITLE
Loosen dependency version requirement

### DIFF
--- a/copy_carrierwave_file.gemspec
+++ b/copy_carrierwave_file.gemspec
@@ -14,11 +14,10 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "carrierwave", "~> 0.9"
+  spec.add_dependency "carrierwave", ">= 0.9"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "activerecord", "~> 3.2"


### PR DESCRIPTION
As CarrierWave is about to release its 1.0.0 version (beta already out), we need to loosen the version requirement.